### PR TITLE
matchspec: Add package to implement renovate-style matching

### DIFF
--- a/matchspec/doc.go
+++ b/matchspec/doc.go
@@ -1,0 +1,90 @@
+// Package matchspec implements a string pattern matching specification for
+// filtering lists of strings using glob and regular expression patterns,
+// including negation support.
+//
+// # Overview
+//
+// This package is a Go implementation of the string pattern matching concept
+// defined by the Renovate project:
+//
+//	https://docs.renovatebot.com/string-pattern-matching/
+//
+// The [Spec] type represents an ordered list of pattern strings. Callers build
+// a Spec from a []string and then call [Match] (or [Spec.Match]) to test
+// whether a candidate string satisfies the spec.
+//
+// # Pattern Types
+//
+// Each element of a [Spec] is one of two pattern types:
+//
+//   - Glob pattern — any string that does not begin with '/'. Evaluated with
+//     the glob rules provided by [barney.ci/shutil.CompileGlob]. Glob matching
+//     is always case-insensitive: both the pattern and the candidate are
+//     lowercased before comparison.
+//
+//   - Regex pattern — a string delimited by forward slashes, e.g. /^abc/.
+//     The closing delimiter may be followed by 'i' (/^abc/i) to make the match
+//     case-insensitive. Regex patterns are case-sensitive by default. Patterns
+//     that begin with '/' but do not end with '/' or '/i' are rejected as
+//     invalid.
+//
+// # Negation
+//
+// Any pattern may be prefixed with '!' to negate it. A negated pattern that
+// matches the candidate causes [Match] to return false immediately, regardless
+// of any positive patterns that may have already matched. Positive patterns
+// have OR semantics: if any positive pattern matches and no negative pattern
+// matches, the result is true.
+//
+// When the Spec contains only negative patterns, the implicit default is true:
+// the candidate is accepted unless at least one negative pattern matches.
+//
+// An empty Spec (or a Spec containing only empty strings) always returns true.
+//
+// # Examples
+//
+// Simple glob match:
+//
+//	s := matchspec.Spec{"src/**/*.go"}
+//	ok, _ := s.Match("src/pkg/foo.go") // true
+//	ok, _ = s.Match("vendor/pkg/foo.go") // false
+//
+// Negation — include everything except a subtree:
+//
+//	s := matchspec.Spec{"!vendor/**"}
+//	ok, _ := s.Match("src/main.go") // true  (no positive patterns; negation didn't fire)
+//	ok, _ = s.Match("vendor/lib/x.go") // false (negation fired)
+//
+// Mixed positive and negative patterns:
+//
+//	s := matchspec.Spec{"src/**", "!src/generated/**"}
+//	ok, _ := s.Match("src/api/handler.go") // true
+//	ok, _ = s.Match("src/generated/pb.go") // false
+//
+// Regex with case-insensitive flag:
+//
+//	s := matchspec.Spec{"/^v\\d+\\.\\d+/i"}
+//	ok, _ := s.Match("V1.2-alpha") // true
+//
+// # Differences from the Renovate Specification
+//
+// This implementation diverges from Renovate's reference implementation in a
+// few areas:
+//
+//   - Regex engine: Renovate uses JavaScript's re2 package. This package uses
+//     Go's standard [regexp] package, which also implements RE2 syntax. The
+//     practical difference is that Go's RE2 enforces stricter syntax in some
+//     edge cases; patterns that are valid in one engine may need adjustment in
+//     the other.
+//
+//   - Glob engine: Renovate evaluates globs with the JavaScript minimatch
+//     library. This package uses [barney.ci/shutil.CompileGlob]. The two
+//     engines share the common glob conventions (*, **, ?) but may differ on
+//     unusual edge cases such as brace expansion or character classes.
+//
+//   - The '*' special case: Renovate documents '*' as a standalone "match
+//     everything" token that cannot be combined with other patterns. This
+//     implementation treats '*' as an ordinary glob that happens to match any
+//     string without a path separator. Combining '*' with other patterns is
+//     not restricted, though the result is the same in practice.
+package matchspec

--- a/matchspec/matchspec.go
+++ b/matchspec/matchspec.go
@@ -1,0 +1,139 @@
+package matchspec
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"barney.ci/shutil"
+)
+
+type Spec []string
+
+func (s Spec) Match(candidate string) (bool, error) {
+	return Match(s, candidate)
+}
+
+func (s Spec) Validate() error {
+	return Validate(s)
+}
+
+// Match returns true if the candidate string matches the list of patterns.
+// Patterns may be globs (case-insensitive) or regexes delimited by slashes,
+// optionally followed by 'i' for case-insensitive matching. Patterns prefixed
+// with '!' are negations: a matched negation immediately returns false.
+// If only negative patterns are present and none match, the result is true.
+func Match(patterns Spec, candidate string) (bool, error) {
+	hasPositivePatterns := false
+	matchedAnyPositive := false
+
+	for _, pattern := range patterns {
+		isNegative := false
+
+		if strings.HasPrefix(pattern, "!") {
+			isNegative = true
+			pattern = pattern[1:]
+		}
+
+		if pattern == "" {
+			continue
+		}
+
+		if !isNegative {
+			hasPositivePatterns = true
+		}
+
+		var matched bool
+		var err error
+		if strings.HasPrefix(pattern, "/") {
+			matched, err = matchRegex(pattern, candidate)
+		} else {
+			matched, err = matchGlob(pattern, candidate)
+		}
+		if err != nil {
+			return false, err
+		}
+
+		if isNegative && matched {
+			// Negative match found: reject immediately
+			return false, nil
+		}
+		if !isNegative && matched {
+			// Positive matches can't be reported until the end (in case
+			// there are also negative matches later in the list).
+			matchedAnyPositive = true
+		}
+	}
+
+	// If we only have negative patterns and none matched, return true.
+	// If we have positive patterns, at least one must have matched.
+	if hasPositivePatterns {
+		return matchedAnyPositive, nil
+	}
+
+	return true, nil
+}
+
+func matchGlob(pattern, candidate string) (bool, error) {
+	// Glob patterns are always case-insensitive.
+	g, err := shutil.CompileGlob(strings.ToLower(pattern))
+	if err != nil {
+		return false, err
+	}
+	return g.Match(strings.ToLower(candidate)), nil
+}
+
+func matchRegex(pattern, candidate string) (bool, error) {
+	trimPattern := pattern
+	caseInsensitive := false
+
+	// Check for case-insensitive flag '/i'
+	if strings.HasSuffix(trimPattern, "/i") {
+		trimPattern = strings.TrimSuffix(trimPattern, "/i")
+		trimPattern = strings.TrimPrefix(trimPattern, "/")
+		caseInsensitive = true
+	} else if strings.HasSuffix(trimPattern, "/") {
+		trimPattern = strings.TrimSuffix(trimPattern, "/")
+		trimPattern = strings.TrimPrefix(trimPattern, "/")
+	} else {
+		return false, fmt.Errorf("invalid regex pattern: %q", pattern)
+	}
+
+	if caseInsensitive {
+		trimPattern = "(?i)" + trimPattern
+	}
+
+	re, err := regexp.Compile(trimPattern)
+	if err != nil {
+		return false, err
+	}
+
+	return re.MatchString(candidate), nil
+}
+
+// Validate checks if the provided patterns are syntactically correct
+// (valid regex or valid glob).
+func Validate(patterns Spec) error {
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, "!") {
+			pattern = pattern[1:]
+		}
+
+		if pattern == "" {
+			// Empty patterns are technically valid (just ignored)
+			continue
+		}
+
+		var err error
+		// We pass an empty candidate (""). We only care about the error return.
+		if strings.HasPrefix(pattern, "/") {
+			_, err = matchRegex(pattern, "")
+		} else {
+			_, err = matchGlob(pattern, "")
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/matchspec/matchspec_test.go
+++ b/matchspec/matchspec_test.go
@@ -1,0 +1,162 @@
+package matchspec
+
+import (
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		patterns  Spec
+		candidate string
+		want      bool
+	}{
+		{
+			name:      "Simple Glob Match",
+			patterns:  []string{"src/**/*.ts"},
+			candidate: "src/app/utils.ts",
+			want:      true,
+		},
+		{
+			name:      "Glob Match Case Insensitive",
+			patterns:  []string{"SRC/**/*.TS"},
+			candidate: "src/app/utils.ts",
+			want:      true,
+		},
+		{
+			name: "Negative Match Overrides Positive",
+			patterns: []string{
+				"src/**/*.ts",
+				"!src/app/utils.ts",
+			},
+			candidate: "src/app/utils.ts",
+			want:      false,
+		},
+		{
+			name:      "Regex Match Case Insensitive",
+			patterns:  []string{"/^SRC\\/.*\\.ts$/i"},
+			candidate: "src/app/utils.ts",
+			want:      true,
+		},
+		{
+			name:      "Regex Match Case Sensitive Failure",
+			patterns:  []string{"/^SRC\\/.*\\.ts$/"},
+			candidate: "src/app/utils.ts",
+			want:      false,
+		},
+		{
+			name:      "Only Negative Patterns (Implicitly Allows Others)",
+			patterns:  []string{"!src/other/**"},
+			candidate: "src/app/utils.ts",
+			want:      true,
+		},
+		{
+			name:      "Only Negative Patterns (Rejection)",
+			patterns:  []string{"!src/app/**"},
+			candidate: "src/app/utils.ts",
+			want:      false,
+		},
+		{
+			name: "Multiple Positive Patterns (OR Logic)",
+			patterns: []string{
+				"docs/**",
+				"src/**/*.go",
+			},
+			candidate: "src/main.go",
+			want:      true,
+		},
+		{
+			name:      "No Patterns Match",
+			patterns:  []string{"docs/**"},
+			candidate: "src/main.go",
+			want:      false,
+		},
+		{
+			name:      "Empty Pattern List (Defaults to True)",
+			patterns:  []string{},
+			candidate: "anything",
+			want:      true,
+		},
+		{
+			name: "Select most release branches but exclude specific ones",
+			patterns: []string{
+				"/^(master|main|.+-release-.+)$/",
+				"!/^(mfw-release-6.0|mfw-release-6.1)$/",
+			},
+			candidate: "mfw-release-6.0",
+			want:      false,
+		},
+		{
+			name: "Select most release branches but exclude specific ones (allowed)",
+			patterns: []string{
+				"/^(master|main|.+-release-.+)$/",
+				"!/^(mfw-release-6.0|mfw-release-6.1)$/",
+			},
+			candidate: "mfw-release-6.2",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Match(tt.patterns, tt.candidate)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		wantErr  bool
+	}{
+		{
+			name: "Valid globs and regexes",
+			patterns: []string{
+				"src/**",
+				"!/^test$/i",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "Invalid Regex Delimiter",
+			patterns: []string{"/missing-slash"},
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid Regex Syntax",
+			patterns: []string{"/unclosed(paren/"},
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid Glob Syntax",
+			patterns: []string{"src/[unclosed"},
+			wantErr:  true,
+		},
+		{
+			name:     "Empty Pattern in List",
+			patterns: []string{"src/**", ""},
+			wantErr:  false, // Ignored, not error
+		},
+		{
+			name:     "Just Negation Operator",
+			patterns: []string{"!"},
+			wantErr:  false, // effectively empty after stripping '!'
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.patterns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The renovate pattern string pattern is extremely useful for configuration because it allows the expressiveness of regex with the conceptual simplicity of a list --- and also allows negative matching.

Any config file that would normally accept a regex or a glob should seriously consider accepting a `barney.ci/shutil/matchspec.Spec` instance instead because of how easy it makes things for the operator.

This implementation is taken from barney.ci/bar/internal/renovatepattern. I've massively expanded the godoc for this since it will be public-facing.